### PR TITLE
Remove global variables, reformat code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+ColumnLimit: 100

--- a/DriverController.ino
+++ b/DriverController.ino
@@ -1,35 +1,38 @@
 /*
-* This file is the main program for the electronic control unit for the Missouri S&T Solar Car.
-* This program is meant to be run on an Arduino Due board and bootloaded using the Arduino IDE.
-*
-*////////////////////////////////////////
+ * This file is the main program for the electronic control unit for the
+ * Missouri S&T Solar Car. This program is meant to be run on an Arduino Due
+ * board and bootloaded using the Arduino IDE.
+ *
+ *////////////////////////////////////////
 
-#include <Arduino.h>
-#include <due_can.h>
-#include <DueTimer.h>
-#include "src/pedal/pedal.h"
 #include "src/can/can.h"
+#include "src/pedal/pedal.h"
 #include "src/pins/pins.h"
-
-
+#include <Arduino.h>
+#include <DueTimer.h>
+#include <due_can.h>
 
 using namespace std;
 
 driveState drive;
 buttonStates buttons;
 
-//timer settup
-DueTimer driveTimer = Timer.getAvailable().attachInterrupt([]() { sendDriveMessage(drive); }).start(100000);
-DueTimer powerTimer = Timer.getAvailable().attachInterrupt([]() { sendPowerMessage(drive); }).start(100000);
+// timer settup
+DueTimer driveTimer = Timer.getAvailable()
+                          .attachInterrupt([]() { sendDriveMessage(drive); })
+                          .start(100000);
+DueTimer powerTimer = Timer.getAvailable()
+                          .attachInterrupt([]() { sendPowerMessage(drive); })
+                          .start(100000);
 
 void setup() {
-  //setup the CAN bus interface
+  // setup the CAN bus interface
   Can0.begin(500000, 255);
   Can1.begin(500000, 255);
 
-  Can0.watchFor();  //allows all canbus traffic through
+  Can0.watchFor(); // allows all canbus traffic through
 
-  Can0.setGeneralCallback(handelMessageCAN); //receive CAN callback
+  Can0.setGeneralCallback(handelMessageCAN); // receive CAN callback
 
   pinInit();
 
@@ -38,17 +41,15 @@ void setup() {
 
 void loop() {
 
-  //update statuses
+  // update statuses
   update_drive_pedal(drive);
   // update_drive_blinkers(drive);
   update_drive_frame(drive);
 
   readButtons(buttons);
   // Serial.println(drive.driveFrame.data.high);
-  
+
   // Serial.println(buttons.left_blinker);
 
   // flashBlinkers(drive);
-  
 }
-

--- a/DriverController.ino
+++ b/DriverController.ino
@@ -15,9 +15,12 @@
 
 using namespace std;
 
+driveState drive;
+buttonStates buttons;
+
 //timer settup
-DueTimer driveTimer = Timer.getAvailable().attachInterrupt(sendDriveMessage).start(100000);
-DueTimer powerTimer = Timer.getAvailable().attachInterrupt(sendPowerMessage).start(100000);
+DueTimer driveTimer = Timer.getAvailable().attachInterrupt([]() { sendDriveMessage(drive); }).start(100000);
+DueTimer powerTimer = Timer.getAvailable().attachInterrupt([]() { sendPowerMessage(drive); }).start(100000);
 
 void setup() {
   //setup the CAN bus interface
@@ -36,11 +39,11 @@ void setup() {
 void loop() {
 
   //update statuses
-  update_drive_pedal();
+  update_drive_pedal(drive);
   // update_drive_blinkers(drive);
-  update_drive_frame();
+  update_drive_frame(drive);
 
-  readButtons();
+  readButtons(buttons);
   // Serial.println(drive.driveFrame.data.high);
   
   // Serial.println(buttons.left_blinker);

--- a/contributing.md
+++ b/contributing.md
@@ -2,5 +2,25 @@
 This is the process that you should follow when contributing to this repository.
 
 1. Create a new branch named after the feature or change you plan to implement. Ex. **brake-lights-implementation**
-2. Commit changes to branch (don't forget to clang-format your code)
+2. Commit changes to branch (ensure your code is clang-formatted; see [Using clang-format](#using-clang-format) for instructions)
 3. Make a PR to request your changes be merged into main and wait for it to be reviewed by another team member before a merging.
+
+# Using clang-format
+To ensure consistent code formatting, we use clang-format. Please follow the instructions below to format your code before committing changes.
+
+## Installing clang-format
+1. Install clang-format on your system. You can find installation instructions for your platform [here](https://clang.llvm.org/docs/ClangFormat.html).
+
+## Formatting code
+1. To format a single file, run the following command:
+   ```
+   clang-format -i <filename>
+   ```
+2. To format all files in the repository, run the following command:
+   ```
+   find . -name "*.ino" -o -name "*.cpp" -o -name "*.h" | xargs clang-format -i
+   ```
+
+## Additional information
+- Make sure to format your code before committing changes to ensure consistency across the codebase.
+- If you encounter any issues with clang-format, please refer to the [clang-format documentation](https://clang.llvm.org/docs/ClangFormat.html) or reach out to a team member for assistance.

--- a/src/can/can.cpp
+++ b/src/can/can.cpp
@@ -10,7 +10,8 @@ void handelMessageCAN(CAN_FRAME *frame)
 };
 
 
-void update_drive_frame()
+void update_drive_frame(driveState &drive)
+
 {
     drive.driveFrame.id = DRIVE_FRAME_ID;
     drive.driveFrame.length = 8;
@@ -20,7 +21,7 @@ void update_drive_frame()
     memcpy(&drive.driveFrame.data.low, &VELOCITY_MAX, sizeof(VELOCITY_MAX));
 };
 
-void update_power_frame()
+void update_power_frame(driveState &drive)
 {
     drive.driveFrame.id = POWER_FRAME_ID;
     drive.driveFrame.length = 8;
@@ -28,14 +29,14 @@ void update_power_frame()
     drive.driveFrame.data.low = 0;
 };
 
-void sendDriveMessage()
+void sendDriveMessage(driveState &drive)
 {
   if (!drive.pedalFault){
     Can0.sendFrame(drive.driveFrame);
   }
 }
 
-void sendPowerMessage()
+void sendPowerMessage(driveState &drive)
 {
     Can0.sendFrame(drive.powerFrame);
 }

--- a/src/can/can.cpp
+++ b/src/can/can.cpp
@@ -1,42 +1,32 @@
-#include <Arduino.h>
 #include "can.h"
+#include <Arduino.h>
 
 #pragma once
 
-void handelMessageCAN(CAN_FRAME *frame)
-{
-
-    return;
-};
-
+void handelMessageCAN(CAN_FRAME *frame) { return; };
 
 void update_drive_frame(driveState &drive)
 
 {
-    drive.driveFrame.id = DRIVE_FRAME_ID;
-    drive.driveFrame.length = 8;
-    // drive.driveFrame.data.high = drive.pedal;
-    // drive.driveFrame.data.low = VELOCITY_MAX;
-    memcpy(&drive.driveFrame.data.high, &drive.pedal, sizeof(drive.pedal));
-    memcpy(&drive.driveFrame.data.low, &VELOCITY_MAX, sizeof(VELOCITY_MAX));
+  drive.driveFrame.id = DRIVE_FRAME_ID;
+  drive.driveFrame.length = 8;
+  // drive.driveFrame.data.high = drive.pedal;
+  // drive.driveFrame.data.low = VELOCITY_MAX;
+  memcpy(&drive.driveFrame.data.high, &drive.pedal, sizeof(drive.pedal));
+  memcpy(&drive.driveFrame.data.low, &VELOCITY_MAX, sizeof(VELOCITY_MAX));
 };
 
-void update_power_frame(driveState &drive)
-{
-    drive.driveFrame.id = POWER_FRAME_ID;
-    drive.driveFrame.length = 8;
-    drive.driveFrame.data.high = drive.busCurrent;
-    drive.driveFrame.data.low = 0;
+void update_power_frame(driveState &drive) {
+  drive.driveFrame.id = POWER_FRAME_ID;
+  drive.driveFrame.length = 8;
+  drive.driveFrame.data.high = drive.busCurrent;
+  drive.driveFrame.data.low = 0;
 };
 
-void sendDriveMessage(driveState &drive)
-{
-  if (!drive.pedalFault){
+void sendDriveMessage(driveState &drive) {
+  if (!drive.pedalFault) {
     Can0.sendFrame(drive.driveFrame);
   }
 }
 
-void sendPowerMessage(driveState &drive)
-{
-    Can0.sendFrame(drive.powerFrame);
-}
+void sendPowerMessage(driveState &drive) { Can0.sendFrame(drive.powerFrame); }

--- a/src/can/can.h
+++ b/src/can/can.h
@@ -12,10 +12,10 @@ const float VELOCITY_MAX = 9000;
 
 void handelMessageCAN(CAN_FRAME *frame);
 
-void update_drive_frame();
+void update_drive_frame(driveState &drive);
 
-void update_power_frame();
+void update_power_frame(driveState &drive);
 
-void sendDriveMessage();
+void sendDriveMessage(driveState &drive);
 
-void sendPowerMessage();
+void sendPowerMessage(driveState &drive);

--- a/src/can/can.h
+++ b/src/can/can.h
@@ -1,5 +1,5 @@
-#include <Arduino.h>
 #include "../states/states.h"
+#include <Arduino.h>
 
 #pragma once
 
@@ -8,7 +8,7 @@
 #define POWER_FRAME_ID 0x502
 // #define VELOCITY_MAX  3000//9000
 
-const float VELOCITY_MAX = 9000;  
+const float VELOCITY_MAX = 9000;
 
 void handelMessageCAN(CAN_FRAME *frame);
 

--- a/src/pedal/pedal.cpp
+++ b/src/pedal/pedal.cpp
@@ -6,7 +6,7 @@
 //INPUT:    pass by reference the drive object
 //OUT:      the pedal member of drive will be written to,
 //          the reversed member of drive will be read from
-void update_drive_pedal(){
+void update_drive_pedal(driveState &drive) {
     
     int baseRaw = analogRead(ACC_BASELINE);
     int pedalRaw = analogRead(ACC_PEDAL);

--- a/src/pedal/pedal.cpp
+++ b/src/pedal/pedal.cpp
@@ -1,46 +1,43 @@
-#include <Arduino.h>
 #include "pedal.h"
+#include <Arduino.h>
 
-
-//DESC:     updates the pedal value in the drive object
-//INPUT:    pass by reference the drive object
-//OUT:      the pedal member of drive will be written to,
-//          the reversed member of drive will be read from
+// DESC:     updates the pedal value in the drive object
+// INPUT:    pass by reference the drive object
+// OUT:      the pedal member of drive will be written to,
+//           the reversed member of drive will be read from
 void update_drive_pedal(driveState &drive) {
-    
-    int baseRaw = analogRead(ACC_BASELINE);
-    int pedalRaw = analogRead(ACC_PEDAL);
 
-    int max = analogRead(ACC_BASELINE) * 0.9;
-    int min = ACC_PEDAL_MIN;
+  int baseRaw = analogRead(ACC_BASELINE);
+  int pedalRaw = analogRead(ACC_PEDAL);
 
-    float pedalValue = pedalRaw;
-    
-    // Checks for weird values and stops the motor
-    if ((analogRead(ACC_BASELINE) < (pedalValue - 50)) || (pedalRaw < min)) {
-      Serial.println("Error: PedalFault!");
-      drive.pedalFault = true;
-      return;
-    } 
-    //Serial.println(pedalValue);   //DEBUG
+  int max = analogRead(ACC_BASELINE) * 0.9;
+  int min = ACC_PEDAL_MIN;
 
-    //scale down to between 0 and 1
-    pedalValue -= min;
-    pedalValue /= max-min;
+  float pedalValue = pedalRaw;
 
-    Serial.print(pedalRaw);
-    Serial.print(" | ");
-    Serial.print(baseRaw);
-    Serial.print(" | ");
-  
-
-    pedalValue = 1 - pedalValue;
-    pedalValue = constrain(pedalValue, 0, 1) * 0.6;
-
-    Serial.println(pedalValue);
-
-    //update pedal value
-    drive.pedal = pedalValue;
+  // Checks for weird values and stops the motor
+  if ((analogRead(ACC_BASELINE) < (pedalValue - 50)) || (pedalRaw < min)) {
+    Serial.println("Error: PedalFault!");
+    drive.pedalFault = true;
     return;
-};
+  }
+  // Serial.println(pedalValue);   //DEBUG
 
+  // scale down to between 0 and 1
+  pedalValue -= min;
+  pedalValue /= max - min;
+
+  Serial.print(pedalRaw);
+  Serial.print(" | ");
+  Serial.print(baseRaw);
+  Serial.print(" | ");
+
+  pedalValue = 1 - pedalValue;
+  pedalValue = constrain(pedalValue, 0, 1) * 0.6;
+
+  Serial.println(pedalValue);
+
+  // update pedal value
+  drive.pedal = pedalValue;
+  return;
+};

--- a/src/pedal/pedal.h
+++ b/src/pedal/pedal.h
@@ -13,4 +13,4 @@
 // INPUT:    pass by reference the drive object
 // OUT:      the pedal member of drive will be written to,
 //           the reversed member of drive will be read from
-void update_drive_pedal();
+void update_drive_pedal(driveState &drive);

--- a/src/pedal/pedal.h
+++ b/src/pedal/pedal.h
@@ -1,13 +1,13 @@
-#include <Arduino.h>
-#include "due_can.h"
-#include "../states/states.h"
 #include "../pins/pins.h"
+#include "../states/states.h"
+#include "due_can.h"
+#include <Arduino.h>
 
 #pragma once
 
 // Variables
 #define ACC_PEDAL_MIN 600
-//#define VELOCITY_MAX 3000 // 9000
+// #define VELOCITY_MAX 3000 // 9000
 
 // DESC:     updates the pedal value in the drive object
 // INPUT:    pass by reference the drive object

--- a/src/pins/pins.cpp
+++ b/src/pins/pins.cpp
@@ -2,26 +2,25 @@
 #include "../states/states.h"
 
 // Initilize pins
-void pinInit()
-{
+void pinInit() {
 
-    // set input pins
-    pinMode(ACC_PEDAL, INPUT);
-    pinMode(BREAK_PEDAL, INPUT);
-    pinMode(TURN_LEFT_BUTTON, INPUT);
-    pinMode(TURN_RIGHT_BUTTON, INPUT);
-    pinMode(DRIVE_DIRECTION_SWITCH, INPUT);
+  // set input pins
+  pinMode(ACC_PEDAL, INPUT);
+  pinMode(BREAK_PEDAL, INPUT);
+  pinMode(TURN_LEFT_BUTTON, INPUT);
+  pinMode(TURN_RIGHT_BUTTON, INPUT);
+  pinMode(DRIVE_DIRECTION_SWITCH, INPUT);
 
-    // set output pins
-    pinMode(HEADLIGHTS, OUTPUT);
-    pinMode(BLINKER_LEFT, OUTPUT);
-    pinMode(BLINKER_RIGHT, OUTPUT);
-    pinMode(BREAKLIGHT, OUTPUT);
-    pinMode(STROBELIGHT, OUTPUT);
+  // set output pins
+  pinMode(HEADLIGHTS, OUTPUT);
+  pinMode(BLINKER_LEFT, OUTPUT);
+  pinMode(BLINKER_RIGHT, OUTPUT);
+  pinMode(BREAKLIGHT, OUTPUT);
+  pinMode(STROBELIGHT, OUTPUT);
 };
 
 void readButtons(buttonStates &buttons) {
-    buttons.left_blinker = digitalRead(TURN_LEFT_BUTTON);
-    buttons.right_blinker = digitalRead(TURN_RIGHT_BUTTON);
-    buttons.cruise_control = digitalRead(CRUISE__CONTROL_BUTTON);
+  buttons.left_blinker = digitalRead(TURN_LEFT_BUTTON);
+  buttons.right_blinker = digitalRead(TURN_RIGHT_BUTTON);
+  buttons.cruise_control = digitalRead(CRUISE__CONTROL_BUTTON);
 };

--- a/src/pins/pins.cpp
+++ b/src/pins/pins.cpp
@@ -20,7 +20,7 @@ void pinInit()
     pinMode(STROBELIGHT, OUTPUT);
 };
 
-void readButtons() {
+void readButtons(buttonStates &buttons) {
     buttons.left_blinker = digitalRead(TURN_LEFT_BUTTON);
     buttons.right_blinker = digitalRead(TURN_RIGHT_BUTTON);
     buttons.cruise_control = digitalRead(CRUISE__CONTROL_BUTTON);

--- a/src/pins/pins.h
+++ b/src/pins/pins.h
@@ -21,4 +21,4 @@
 
 void pinInit();
 
-void readButtons();
+void readButtons(buttonStates &buttons);

--- a/src/pins/pins.h
+++ b/src/pins/pins.h
@@ -3,21 +3,21 @@
 #pragma once
 
 /////   PIN DEFINITIONS
-//inputs
-#define ACC_PEDAL              A7
-#define ACC_BASELINE           A6
-#define BREAK_PEDAL            84
-#define DRIVE_DIRECTION_SWITCH 21  //High for reverse, Low for forward
-#define TURN_LEFT_BUTTON       52 //20
-#define TURN_RIGHT_BUTTON      132
-#define CRUISE__CONTROL_BUTTON 133 
+// inputs
+#define ACC_PEDAL A7
+#define ACC_BASELINE A6
+#define BREAK_PEDAL 84
+#define DRIVE_DIRECTION_SWITCH 21 // High for reverse, Low for forward
+#define TURN_LEFT_BUTTON 52       // 20
+#define TURN_RIGHT_BUTTON 132
+#define CRUISE__CONTROL_BUTTON 133
 
-//outputs
-#define HEADLIGHTS          65
-#define BLINKER_LEFT        67
-#define BLINKER_RIGHT       71
-#define BREAKLIGHT          101
-#define STROBELIGHT         55
+// outputs
+#define HEADLIGHTS 65
+#define BLINKER_LEFT 67
+#define BLINKER_RIGHT 71
+#define BREAKLIGHT 101
+#define STROBELIGHT 55
 
 void pinInit();
 

--- a/src/states/states.cpp
+++ b/src/states/states.cpp
@@ -2,5 +2,3 @@
 
 // this will hold all the data relevent to the status of the car
 // blinkerState blinkers;
-driveState drive;
-buttonStates buttons;

--- a/src/states/states.h
+++ b/src/states/states.h
@@ -22,6 +22,3 @@ struct buttonStates
     int right_blinker; // true -> flash right blinker
     int cruise_control; // true -> enable cruise control
 };
-
-extern driveState drive;
-extern buttonStates buttons;

--- a/src/states/states.h
+++ b/src/states/states.h
@@ -1,24 +1,25 @@
-#include <Arduino.h>
 #include "due_can.h"
+#include <Arduino.h>
 
 #pragma once
 
-struct driveState
-{
-    CAN_FRAME driveFrame;      // contains the current status of the drive frame that is sent to the motor controller
-    CAN_FRAME powerFrame;      // contains the current status of the power frame that is sent to the motor controller
-    uint32_t busCurrent = 1.0; // drawn current from the power bus according to current limit
+struct driveState {
+  CAN_FRAME driveFrame; // contains the current status of the drive frame that
+                        // is sent to the motor controller
+  CAN_FRAME powerFrame; // contains the current status of the power frame that
+                        // is sent to the motor controller
+  uint32_t busCurrent =
+      1.0; // drawn current from the power bus according to current limit
 
-    float pedal;   // floating point value between 0 and 1
-    bool reversed; // true -> driving in reverse; false -> driving forward
-    bool pedalFault = false;
-    bool BPSfault; // true -> fault
-    bool breaking; // true -> break pedal applied, turn on break lights
+  float pedal;   // floating point value between 0 and 1
+  bool reversed; // true -> driving in reverse; false -> driving forward
+  bool pedalFault = false;
+  bool BPSfault; // true -> fault
+  bool breaking; // true -> break pedal applied, turn on break lights
 };
 
-struct buttonStates
-{
-    int left_blinker;  // true -> flash left blinker
-    int right_blinker; // true -> flash right blinker
-    int cruise_control; // true -> enable cruise control
+struct buttonStates {
+  int left_blinker;   // true -> flash left blinker
+  int right_blinker;  // true -> flash right blinker
+  int cruise_control; // true -> enable cruise control
 };


### PR DESCRIPTION
This pull request includes several changes to the `DriverController.ino` and related files to improve code organization and functionality. The most important changes include reordering includes, refactoring functions to use references, and updating the `driveState` and `buttonStates` structures.

### Code Organization:

Fixed inconsistencies in the formatting

### Function Refactoring:

* [`DriverController.ino`](diffhunk://#diff-8d497112ed6801b4cd48deff87eedee86f1e4f18ee8e84065bb8f95b297effb8L39-L51): Refactored `DueTimer` setup to use lambda functions and updated function calls to pass `drive` and `buttons` by reference.
* `src/can/can.cpp`, `src/pedal/pedal.cpp`: Updated functions to accept `driveState` by reference. [[1]](diffhunk://#diff-0138db3119929d3412816d71baa2227b37fec74b8b8899e895d402b4e2f3f6a2L1-L13) [[2]](diffhunk://#diff-cc7a99d9810882d0ce31288c17f297f3e1b9f3da236c3624f4568e517316aa24L1-R8)
* [`src/pins/pins.cpp`](diffhunk://#diff-7ec89206d4b90e1a4220f68b53828944940e0ed255729e1cd48578770f9aa9afL23-R22): Updated `readButtons` to accept `buttonStates` by reference.

### Structure Updates:

* [`src/states/states.cpp`](diffhunk://#diff-ed77275d8a38e5c5e31c97d31d17c3ed95fce4ee8299c593c9faac625c944bc9L5-L6): Removed global instances of `driveState` and `buttonStates`.